### PR TITLE
Fix: List.Take: nil dereference

### DIFF
--- a/linked_test.go
+++ b/linked_test.go
@@ -1103,14 +1103,20 @@ func (ts *TestSuite[T]) testListTake(t *testing.T, edge linked.Edge) {
 	list := ts.List()
 	size := list.Len()
 
-	if size == 0 {
-		return // nothing to do
-	} else if expect = Reversed(ts.Values()); edge.Must() == linked.Before {
+	if expect = Reversed(ts.Values()); edge.Must() == linked.Before {
 		take = list.TakeBefore
 		expect = slices.Concat(expect, ts.Values())
 	} else {
 		take = list.TakeAfter
 		expect = slices.Concat(ts.Values(), expect)
+	}
+
+	if size == 0 {
+		var zero linked.Node[T]
+		_ = AssertSame(t, &zero, take(&zero, nil), "should inherit at %s of %T", edge.List(), list) &&
+			Assert(t, true, zero.IsMember(list), "should be a member of %T", list)
+
+		return
 	}
 
 	oppo := edge.Opposite()

--- a/list.go
+++ b/list.go
@@ -378,7 +378,13 @@ func (l *List[T]) Take(inherit, target *Node[T], edge Edge) *Node[T] {
 		inherit.Pop()
 	}
 
-	l.insert(&span[T]{inherit, inherit}, target, edge)
+	if inherit.list = l; target == nil {
+		l.edges[Front] = inherit
+		l.edges[Back] = inherit
+	} else {
+		l.insert(&span[T]{inherit, inherit}, target, edge)
+	}
+
 	l.length++
 	l.version++
 	return inherit


### PR DESCRIPTION
* Fixes nil dereference for implicit target in `List.Take` (and variants)
* Fixes test case for zero-length lists in `List.Take`